### PR TITLE
FIX: add PLUGIN_NAME to template

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -10,5 +10,7 @@
 
 enabled_site_setting :plugin_name_enabled
 
+PLUGIN_NAME ||= -"discourse-plugin-name"
+
 after_initialize do
 end


### PR DESCRIPTION
without setting the plugin name like this ember will not pick up changes. Not including this in the template can be very demotivating for beginners, because there is no mention anywhere that this is needed.