### PR TITLE
Delete translator.yml

### DIFF
--- a/translator.yml
+++ b/translator.yml
@@ -1,7 +1,0 @@
-# Configuration file for discourse-translator-bot
-
-files:
-  - source_path: config/locales/client.en.yml
-    destination_path: client.yml
-  - source_path: config/locales/server.en.yml
-    destination_path: server.yml


### PR DESCRIPTION
This file shouldn't be part of the skeleton. The translator bot will create an appropriate file when the repo gets added to Crowdin.