### PR TITLE
DEV: Remove `transpile_js: true`

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -6,7 +6,6 @@
 # authors: Discourse
 # url: TODO
 # required_version: 2.7.0
-# transpile_js: true
 
 enabled_site_setting :plugin_name_enabled
 


### PR DESCRIPTION
Plugin js is now transpiled by default (see: https://github.com/discourse/discourse/pull/17175)