### PR TITLE
DEV: Sets the `plugin_name_enabled` flag to false

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,4 +1,4 @@
 plugins:
   plugin_name_enabled:
-    default: true
+    default: false
     client: true


### PR DESCRIPTION
Plugins in general should be disabled by default, requiring an admin to explicitly enable them.