### PR TITLE
Revert "DEV: Pin plugin for Discourse < 3.3.0.beta1-dev (#46)"

### DIFF
--- a/.discourse-compatibility
+++ b/.discourse-compatibility
@@ -1,2 +1,0 @@
-< 3.3.0.beta1-dev: f1c7ada2637c52f4239420ebce8ac2e880d8de30
-


### PR DESCRIPTION
This reverts commit 9548e90f458b0c6ebc61aff07d28fee94e0d50a2. 

We pin plugins when we release stable, but no need to pin the skeleton. 